### PR TITLE
Return Maybe instead of `fail`-ing in a monad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp

--- a/Data/IntMultiSet.hs
+++ b/Data/IntMultiSet.hs
@@ -356,18 +356,18 @@ deleteFindMax :: IntMultiSet -> (Key,IntMultiSet)
 deleteFindMax set = (findMax set, deleteMax set)
 
 -- | /O(log n)/. Retrieves the minimal element of the multiset, and the set stripped from that element
--- @fail@s (in the monad) when passed an empty multiset.
-minView :: Monad m => IntMultiSet -> m (Key, IntMultiSet)
+-- Returns @Nothing@ when passed an empty multiset.
+minView :: IntMultiSet -> Maybe (Key, IntMultiSet)
 minView x
-  | null x    = fail "IntMultiSet.minView: empty multiset"
-  | otherwise = return (deleteFindMin x)
+  | null x    = Nothing
+  | otherwise = Just (deleteFindMin x)
 
 -- | /O(log n)/. Retrieves the maximal element of the multiset, and the set stripped from that element
 -- @fail@s (in the monad) when passed an empty multiset.
-maxView :: Monad m => IntMultiSet -> m (Key, IntMultiSet)
+maxView :: IntMultiSet -> Maybe (Key, IntMultiSet)
 maxView x
-  | null x    = fail "IntMultiSet.maxView: empty multiset"
-  | otherwise = return (deleteFindMin x)
+  | null x    = Nothing
+  | otherwise = Just (deleteFindMin x)
 
 {--------------------------------------------------------------------
   Union, Difference, Intersection

--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -342,19 +342,19 @@ deleteFindMax set = (findMax set, deleteMax set)
 
 -- | /O(log n)/. Retrieves the minimal element of the multiset,
 --   and the set with that element removed.
---   @fail@s (in the monad) when passed an empty multiset.
-minView :: Monad m => MultiSet a -> m (a, MultiSet a)
+--   Returns @Nothing@ when passed an empty multiset.
+minView :: MultiSet a -> Maybe (a, MultiSet a)
 minView x
-  | null x    = fail "MultiSet.minView: empty multiset"
-  | otherwise = return (deleteFindMin x)
+  | null x    = Nothing
+  | otherwise = Just (deleteFindMin x)
 
 -- | /O(log n)/. Retrieves the maximal element of the multiset,
 --   and the set with that element removed.
---   @fail@s (in the monad) when passed an empty multiset.
-maxView :: Monad m => MultiSet a -> m (a, MultiSet a)
+--   Returns @Nothing@ when passed an empty multiset.
+maxView :: MultiSet a -> Maybe (a, MultiSet a)
 maxView x
-  | null x    = fail "MultiSet.maxView: empty multiset"
-  | otherwise = return (deleteFindMin x)
+  | null x    = Nothing
+  | otherwise = Just (deleteFindMin x)
 
 {--------------------------------------------------------------------
   Union, Difference, Intersection


### PR DESCRIPTION
Polymorphic `fail` is considered bad style these days.

Given that `containers` switched to Maybe long ago, it makes sense for
`multiset` to follow in their lead.

I also added a `.gitignore` file, as per convention.