### PR TITLE
Fix #7: Use PackageImports extension in test Main module to fix module ambiguities

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE PackageImports #-}
+
 module Main (main) where
 
-import System.FilePath.Glob (glob)
-import Test.DocTest (doctest)
+import "Glob" System.FilePath.Glob (glob)
+import "doctest" Test.DocTest (doctest)
 
 main :: IO ()
 main = do


### PR DESCRIPTION
This change will fix the doctest failures in the Stackage build.
