### PR TITLE
Issue #11: Fix Haddock formatting of examples for minView and maxView

### DIFF
--- a/Data/IntMultiSet.hs
+++ b/Data/IntMultiSet.hs
@@ -363,6 +363,7 @@ deleteFindMax set = (findMax set, deleteMax set)
 -- Returns @Nothing@ when passed an empty multiset.
 --
 -- Examples:
+--
 -- >>> minView $ fromList [100, 100, 200, 300]
 -- Just (100,fromOccurList [(100,1),(200,1),(300,1)])
 minView :: IntMultiSet -> Maybe (Key, IntMultiSet)
@@ -374,6 +375,7 @@ minView x
 -- @fail@s (in the monad) when passed an empty multiset.
 --
 -- Examples:
+--
 -- >>> maxView $ fromList [100, 100, 200, 300]
 -- Just (300,fromOccurList [(100,2),(200,1)])
 maxView :: IntMultiSet -> Maybe (Key, IntMultiSet)

--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -349,6 +349,7 @@ deleteFindMax set = (findMax set, deleteMax set)
 --   Returns @Nothing@ when passed an empty multiset.
 --
 -- Examples:
+--
 -- >>> minView $ fromList ['a', 'a', 'b', 'c']
 -- Just ('a',fromOccurList [('a',1),('b',1),('c',1)])
 minView :: MultiSet a -> Maybe (a, MultiSet a)
@@ -361,6 +362,7 @@ minView x
 --   Returns @Nothing@ when passed an empty multiset.
 --
 -- Examples:
+--
 -- >>> maxView $ fromList ['a', 'a', 'b', 'c']
 -- Just ('c',fromOccurList [('a',2),('b',1)])
 maxView :: MultiSet a -> Maybe (a, MultiSet a)


### PR DESCRIPTION
This adds the missing blank line between "Examples:" and the first doctest example.
