### PR TITLE
Issue #15: Add include path when invoking doctest to eliminate warnin…

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,8 +5,14 @@ module Main (main) where
 import "Glob" System.FilePath.Glob (glob)
 import "doctest" Test.DocTest (doctest)
 
+includeDirs :: [String]
+includeDirs = ["include"]
+
+doctestWithIncludeDirs :: [String] -> IO ()
+doctestWithIncludeDirs fs = doctest (map ((++) "-I") includeDirs ++ fs)
+
 main :: IO ()
 main = do
-  glob "Data/**/*.hs" >>= doctest
-  glob "test/**/*.hs" >>= doctest
+  glob "Data/**/*.hs" >>= doctestWithIncludeDirs
+  glob "test/**/*.hs" >>= doctestWithIncludeDirs
 


### PR DESCRIPTION
This fix invokes doctest with include directories to pick up the correct instance of `Typeable.h`.