### PR TITLE
Fixes #18: Do not include Typeable.h in GHC 8 and above

### DIFF
--- a/Data/IntMultiSet.hs
+++ b/Data/IntMultiSet.hs
@@ -672,8 +672,10 @@ instance Read IntMultiSet where
   Typeable/Data
 --------------------------------------------------------------------}
 
+#if __GLASGOW_HASKELL__ < 800
 #include "Typeable.h"
 INSTANCE_TYPEABLE0(IntMultiSet,intMultiSetTc,"IntMultiSet")
+#endif
 
 {--------------------------------------------------------------------
   Split

--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -666,8 +666,10 @@ instance (Read a, Ord a) => Read (MultiSet a) where
   Typeable/Data
 --------------------------------------------------------------------}
 
+#if __GLASGOW_HASKELL__ < 800
 #include "Typeable.h"
 INSTANCE_TYPEABLE1(MultiSet,multiSetTc,"MultiSet")
+#endif
 
 {--------------------------------------------------------------------
   Split


### PR DESCRIPTION
This should fix the compiler errors under GHC 8.0.