### PR TITLE
Fix #25: Revert fixes for compiler warnings under GHC 7.8.4

### DIFF
--- a/Data/IntMultiSet.hs
+++ b/Data/IntMultiSet.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ < 710
-{-# OPTIONS_GHC -fno-warn-amp #-}
-#endif
 #if __GLASGOW_HASKELL__
 {-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
 #endif

--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ < 710
-{-# OPTIONS_GHC -fno-warn-amp #-}
-#endif
 #if __GLASGOW_HASKELL__
 {-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
 #endif


### PR DESCRIPTION
With this change, we will now omit AMP-related warnings like before.
However, we can now build on earlier versions of GHC without errors
related to the unknown compiler switch "-fno-warn-amp".

This reverts commit 5aebca1b6ceca62e87e7cfb1ad3338a6d350f58f.