### PR TITLE
Improve performance of `unions`

### DIFF
--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -198,6 +198,7 @@ instance Ord a => Monoid (MultiSet a) where
 #if MIN_VERSION_base(4,11,0)
 instance Ord a => Semigroup (MultiSet a) where
     (<>) = union
+    {-# INLINE (<>) #-}
     sconcat = unions . Data.List.NonEmpty.toList
     stimes = stimesIdempotentMonoid
 #endif

--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -390,11 +390,13 @@ maxView x
   Union, Difference, Intersection
 --------------------------------------------------------------------}
 
+{-# INLINE unions #-}
 -- | The union of a list of multisets: (@'unions' == 'foldl' 'union' 'empty'@).
 unions :: Ord a => [MultiSet a] -> MultiSet a
 unions
   = MS . Map.unionsWith (+) . fmap unMS
 
+{-# INLINE union #-}
 -- | /O(n+m)/. The union of two multisets. The union adds the occurrences together.
 -- 
 -- The implementation uses the efficient /hedge-union/ algorithm.

--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -392,8 +392,8 @@ maxView x
 
 -- | The union of a list of multisets: (@'unions' == 'foldl' 'union' 'empty'@).
 unions :: Ord a => [MultiSet a] -> MultiSet a
-unions ts
-  = foldlStrict union empty ts
+unions
+  = MS . Map.unionsWith (+) . fmap unMS
 
 -- | /O(n+m)/. The union of two multisets. The union adds the occurrences together.
 -- 
@@ -704,18 +704,6 @@ split a = (\(x,y) -> (MS x, MS y)) . Map.split a . unMS
 splitOccur :: Ord a => a -> MultiSet a -> (MultiSet a,Occur,MultiSet a)
 splitOccur a (MS t) = let (l,m,r) = Map.splitLookup a t in
      (MS l, maybe 0 id m, MS r)
-
-{--------------------------------------------------------------------
-  Utilities
---------------------------------------------------------------------}
-
--- TODO : Use foldl' from base?
-foldlStrict :: (a -> t -> a) -> a -> [t] -> a
-foldlStrict f z xs
-  = case xs of
-      []     -> z
-      (x:xx) -> let z' = f z x in seq z' (foldlStrict f z' xx)
-
 
 {--------------------------------------------------------------------
   Debugging

--- a/multiset.cabal
+++ b/multiset.cabal
@@ -1,5 +1,5 @@
 name:             multiset
-version:          0.3.4
+version:          0.3.5
 author:           Twan van Laarhoven
 maintainer:       twanvl@gmail.com
 bug-reports:      https://github.com/twanvl/multiset/issues


### PR DESCRIPTION
This implements `unions` using `unionsWith` from the underlying
representation.

Before:

    λ mconcat $ take 100000000 $ cycle [singleton ()]
    fromOccurList [((),100000000)]
    (36.16 secs, 37,600,131,760 bytes)

After:

    λ mconcat $ take 100000000 $ cycle [singleton ()]
    fromOccurList [((),100000000)]
    (7.48 secs, 20,800,129,488 bytes)