### PR TITLE
Fix stimes

### DIFF
--- a/Data/IntMultiSet.hs
+++ b/Data/IntMultiSet.hs
@@ -139,7 +139,7 @@ import Data.Monoid (Monoid(..))
 #endif
 #if MIN_VERSION_base(4,11,0)
 import qualified Data.List.NonEmpty (toList)
-import Data.Semigroup (Semigroup(..), stimesIdempotentMonoid)
+import Data.Semigroup (Semigroup(..))
 #endif
 import Data.Typeable ()
 import Data.IntMap.Strict (IntMap)
@@ -204,7 +204,10 @@ instance Monoid IntMultiSet where
 instance Semigroup IntMultiSet where
     (<>) = union
     sconcat = unions . Data.List.NonEmpty.toList
-    stimes = stimesIdempotentMonoid
+    stimes n ms@(MS m)
+      | n <= 0    = empty
+      | n == 1    = ms
+      | otherwise = MS $ Map.map (* fromIntegral n) m
 #endif
 
 instance NFData IntMultiSet where

--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -145,7 +145,7 @@ import Data.Monoid (Monoid(..))
 #endif
 #if MIN_VERSION_base(4,11,0)
 import qualified Data.List.NonEmpty (toList)
-import Data.Semigroup (Semigroup(..), stimesIdempotentMonoid)
+import Data.Semigroup (Semigroup(..))
 #endif
 import Data.Typeable ()
 import qualified Data.Foldable as Foldable
@@ -204,7 +204,10 @@ instance Ord a => Monoid (MultiSet a) where
 instance Ord a => Semigroup (MultiSet a) where
     (<>) = union
     sconcat = unions . Data.List.NonEmpty.toList
-    stimes = stimesIdempotentMonoid
+    stimes n ms@(MS m)
+      | n <= 0    = empty
+      | n == 1    = ms
+      | otherwise = MS $ Map.map (* fromIntegral n) m
 #endif
 
 instance Foldable.Foldable MultiSet where


### PR DESCRIPTION
The previous definition was inconsistent with (<>):

    λ x = singleton True
    λ x <> x
    fromOccurList [(True,2)]
    λ stimes 2 x
    fromOccurList [(True,1)]