### PR TITLE
Generalize unions to Foldables

### DIFF
--- a/Data/IntMultiSet.hs
+++ b/Data/IntMultiSet.hs
@@ -139,6 +139,10 @@ import qualified Data.List.NonEmpty (toList)
 import Data.Semigroup (Semigroup(..))
 #endif
 import Data.Typeable ()
+import qualified Data.Foldable as Foldable
+#if !MIN_VERSION_base(4,8,0)
+import Data.Foldable (Foldable())
+#endif
 import Data.IntMap.Strict (IntMap)
 import Data.IntSet (IntSet)
 import Data.MultiSet (MultiSet)
@@ -412,9 +416,8 @@ maxView x
 --------------------------------------------------------------------}
 
 -- | The union of a list of multisets: (@'unions' == 'foldl' 'union' 'empty'@).
-unions :: [IntMultiSet] -> IntMultiSet
-unions ts
-  = foldlStrict union empty ts
+unions :: (Foldable f) => f IntMultiSet -> IntMultiSet
+unions = Foldable.foldl' union empty
 
 -- | /O(n+m)/. The union of two multisets. The union adds the occurrences together.
 --
@@ -717,18 +720,6 @@ split a = (\(x,y) -> (MS x, MS y)) . Map.split a . unMS
 splitOccur :: Int -> IntMultiSet -> (IntMultiSet,Int,IntMultiSet)
 splitOccur a (MS t) = let (l,m,r) = Map.splitLookup a t in
      (MS l, maybe 0 id m, MS r)
-
-{--------------------------------------------------------------------
-  Utilities
---------------------------------------------------------------------}
-
--- TODO : Use foldl' from base?
-foldlStrict :: (a -> t -> a) -> a -> [t] -> a
-foldlStrict f z xs
-  = case xs of
-      []     -> z
-      (x:xx) -> let z' = f z x in seq z' (foldlStrict f z' xx)
-
 
 {--------------------------------------------------------------------
   Debugging

--- a/Data/MultiSet.hs
+++ b/Data/MultiSet.hs
@@ -150,6 +150,9 @@ import Data.Semigroup (stimesMonoid)
 #endif
 import Data.Typeable ()
 import qualified Data.Foldable as Foldable
+#if !MIN_VERSION_base(4,8,0)
+import Data.Foldable (Foldable())
+#endif
 import Data.Map.Strict (Map)
 import Data.Set (Set)
 #if MIN_VERSION_containers(0,5,11)
@@ -438,9 +441,8 @@ maxView x
 --------------------------------------------------------------------}
 
 -- | The union of a list of multisets: (@'unions' == 'foldl' 'union' 'empty'@).
-unions :: Ord a => [MultiSet a] -> MultiSet a
-unions ts
-  = foldlStrict union empty ts
+unions :: (Foldable f, Ord a) => f (MultiSet a) -> MultiSet a
+unions = Foldable.foldl' union empty
 
 -- | /O(n+m)/. The union of two multisets. The union adds the occurrences together.
 -- 
@@ -750,18 +752,6 @@ split a = (\(x,y) -> (MS x, MS y)) . Map.split a . unMS
 splitOccur :: Ord a => a -> MultiSet a -> (MultiSet a,Occur,MultiSet a)
 splitOccur a (MS t) = let (l,m,r) = Map.splitLookup a t in
      (MS l, maybe 0 id m, MS r)
-
-{--------------------------------------------------------------------
-  Utilities
---------------------------------------------------------------------}
-
--- TODO : Use foldl' from base?
-foldlStrict :: (a -> t -> a) -> a -> [t] -> a
-foldlStrict f z xs
-  = case xs of
-      []     -> z
-      (x:xx) -> let z' = f z x in seq z' (foldlStrict f z' xx)
-
 
 {--------------------------------------------------------------------
   Debugging


### PR DESCRIPTION
This PR generalizes `unions` for `MultiSet` and `IntMultiSet` to work on any `Foldable`s (instead of lists) as `Set` and `IntSet` do since commit https://github.com/haskell/containers/commit/b1a1e2f7239b697e2bc08a4d8e448492333330b6.

Removed `foldlStrict` since it isn't used anymore.