### PR TITLE
Bump deepseq dependency

### DIFF
--- a/multiset.cabal
+++ b/multiset.cabal
@@ -29,7 +29,7 @@ Library
   include-dirs:       include
   default-extensions: CPP
   ghc-options:        -Wall
-  build-depends:      containers >= 0.5.4, base >= 4 && < 5, deepseq >=1.2 && <1.5
+  build-depends:      containers >= 0.5.4, base >= 4 && < 5, deepseq >=1.2 && <1.6
 
 test-suite doctests
   default-language:   Haskell2010


### PR DESCRIPTION
This is required to built this package with `ghc-9.8`.

Would appreciate a Hackage metadata edit to fix this as well.